### PR TITLE
Telling user about EssentialsX - Village Defence

### DIFF
--- a/docs/villagedefense/support/useful-server-admin-tips.md
+++ b/docs/villagedefense/support/useful-server-admin-tips.md
@@ -115,6 +115,6 @@ Basically the party plugin on spigot works as a bridge beetween bungee - (spigot
 
 **3. Profit**
 
-:::caution
+:::note
 When using **EssentialsX** make sure to set respawn-listener-priority to normal or low!
 :::

--- a/docs/villagedefense/support/useful-server-admin-tips.md
+++ b/docs/villagedefense/support/useful-server-admin-tips.md
@@ -91,7 +91,7 @@ This command will give you **12 hour** server booster for your default group.
 **(3.)** Only if you use PAF for Bungee, you will need to install the [PAF Addon](https://www.spigotmc.org/resources/39751/) and follow the instruction of it.
 
 :::note
-Basically the party plugin on spigot works as a brige beetween bungee - (spigot) - our minigame
+Basically the party plugin on spigot works as a bridge beetween bungee - (spigot) - our minigame
 :::
 
 **3. Profit**
@@ -114,3 +114,7 @@ Basically the party plugin on spigot works as a brige beetween bungee - (spigot)
 **2.** Set it up like the plugin thread says it
 
 **3. Profit**
+
+:::caution
+When using **EssentialsX** make sure to set respawn-listener-priority to normal or low!
+:::


### PR DESCRIPTION
Tells user to change respawn-listener-priority to normal or low in EssentialsX!
It also corrects a spelling error