### PR TITLE
Fix cmd-perms.mdx Tip error

### DIFF
--- a/docs/minigame/setup/cmd-perms.mdx
+++ b/docs/minigame/setup/cmd-perms.mdx
@@ -240,7 +240,7 @@ You can use `murdermystery.admin.*` permission to give all admin commands permis
 <TabItem value="thebridge">
 
 :::tip
-You can use `murdermystery.admin.*` permission to give all admin commands permission
+You can use `thebridge.admin.*` permission to give all admin commands permission
 :::
 
 | Command                                                                        | Permission                                                         | Description                                                                     | Valid excecutors |


### PR DESCRIPTION
I noticed that the tip above the “The Bridge” category in the Admin commands section of the Wiki was incorrect, as it said “murdermystery” instead of “thebridge”, so I fixed this issue.